### PR TITLE
Feat: #14 add link to documentation template PR list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 Please go to the `Preview` tab and select the appropriate sub-template:
 
 * [Feature PR](?expand=1&template=feature_request.md)
+* [Documentation Update PR](?expand=1&template=documentation_update.md)
 
 Or, remove all text and describe your Pull Request!
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Please go to the `Preview` tab and select the appropriate sub-template:
 
-* [Feature PR](?expand=1&template=feature_request.md)
+* [Feature PR](?expand=1&template=feature_request.md&title=Feat+%3A&labels=enhancement&assignees=idembele70)
 * [Documentation Update PR](?expand=1&template=documentation_update.md)
 
 Or, remove all text and describe your Pull Request!


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
------------------------------------------------------
- Add a link to the documentation pull request template in `PULL_REQUEST_TEMPLATE.md`.
- Add default labels & assignees to the Feature request template link option.

Does this close any currently open issues?
---------------------------------------------
Closes #14 

Any other comments?
-----------------------
<!-- Any other Information or context you think is relevant to the reviewers. -->

I'm not a dummy, so I've checked these
-----------------------------------------
- [X] I made a **self-review**.

